### PR TITLE
fix: typo in default content

### DIFF
--- a/src/components/SimpleNewsletter.vue
+++ b/src/components/SimpleNewsletter.vue
@@ -54,7 +54,7 @@ export default {
       slotProps: {
         mail: '',
         title: title || 'Newsletter',
-        content: content || 'Subscribe to get my lastest content. No spam.',
+        content: content || 'Subscribe to get my latest content. No spam.',
         submitText: submitText || 'Subscribe',
       },
     };


### PR DESCRIPTION
# Fix Content Spelling
Simply changes 'Subscribe to get my lastest content. No spam.' to 'Subscribe to get my latest content. No spam.' on component SimpleNewsletter.vue

## Related Issues

#5 